### PR TITLE
fix: browser restriction error for audio playing

### DIFF
--- a/js/musicplayer.js
+++ b/js/musicplayer.js
@@ -18,21 +18,28 @@ let songAlbum='Sangamam';
 let songYear='2023';
 const songOtherDetails=document.getElementById('songOtherDetails');
 const circleIcon='<i class="fas fa-circle fa-xs"></i>';
-// selectedSong.muted=true;
-window.addEventListener('load', () => {
-    selectedSong.play().catch(error => {
-        console.error('Autoplay failed:', error);
-    });
-    clearInterval(sliderProgress);  
-    sliderprogress = setInterval(() => {
-        var currTime = Math.floor(selectedSong.currentTime);  //round down to nearest integer
-        var percentageComplete = Math.floor((currTime / selectedSong.duration) * 100);
-        songProgress.value = percentageComplete;
-        songMinutes=Math.floor(currTime/60);
-        songSeconds=Math.floor(currTime%60);
-        document.getElementById('selectedSongTime').innerHTML=songMinutes+":"+songSeconds;
-    }, 1000);
-});
+
+playPauseBtn.addEventListener("click",togglePlayPause);
+function togglePlayPause(){
+    if(selectedSong.paused){
+        selectedSong.play();
+        clearInterval(sliderProgress);  
+        sliderprogress = setInterval(() => {
+            var currTime = Math.floor(selectedSong.currentTime);  //round down to nearest integer
+            var percentageComplete = Math.floor((currTime / selectedSong.duration) * 100);
+            songProgress.value = percentageComplete;
+            console.log(percentageComplete);
+            songMinutes=Math.floor(currTime/60);
+            songSeconds=Math.floor(currTime%60);
+            document.getElementById('selectedSongTime').innerHTML=songMinutes+":"+songSeconds;
+        }, 1000);
+        playPauseBtn.innerHTML=pauseIcon;
+    }
+    else{
+        selectedSong.pause();
+        playPauseBtn.innerHTML=playIcon;
+    }
+}
 
 playerSongImage.src=songImage;
 songName.innerHTML=songName_;
@@ -45,21 +52,5 @@ songProgress.addEventListener('input',()=>{
   })
 
 
-playPauseBtn.addEventListener("click",togglePlayPause);
-function togglePlayPause(){
-    if(selectedSong.paused){
-        selectedSong.play();
-    }
-    else{
-        selectedSong.pause();
-    }
-    if(isPlaying){
-        playPauseBtn.innerHTML=pauseIcon;
-    }
-    else{
-        playPauseBtn.innerHTML=playIcon;
-    }
-    isPlaying=!isPlaying;
 
-}
 


### PR DESCRIPTION
Browsers have a security feature that sometimes stops audio from playing directly on webpage launch without any user interaction. Worked around this issue by making the audio play only when the play button is pressed , rather than on webpage launch. Also changed the display code for play and pause button icons to correctly correspond to whether the audio is playing or not.